### PR TITLE
Use keepjumps to avoid adding unnecessary jump

### DIFF
--- a/plugin/qargs.vim
+++ b/plugin/qargs.vim
@@ -1,4 +1,4 @@
-command! -nargs=0 -bar Qargs execute 'args' QuickfixFilenames()
+command! -nargs=0 -bar Qargs execute 'keepjumps args' QuickfixFilenames()
 function! QuickfixFilenames()
   " Building a hash ensures we get each buffer only once
   let buffer_numbers = {}


### PR DESCRIPTION
Using :args jumps to the first file. For some reason this adds two
entries to the jumplist. I don't quite understand, but I don't think we
want to mess with the jumplist so we can jump back to where we came
from.

Verified with:

    gvim -Nu NONE +'source ~/.vim/bundle/sensible/plugin/sensible.vim' +'source ~/.vim/bundle/qargs/plugin/qargs.vim' +'grep! dave *.cmd ' README.rst
    :Qargs
    <C-o>

Before this change, nothing happens.
After this change, you jump back to the README.

Related to #4 